### PR TITLE
Add test-ci script in package.json

### DIFF
--- a/frontend/mycargonaut/package.json
+++ b/frontend/mycargonaut/package.json
@@ -7,6 +7,7 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "test-ci": "ng test --watch=false --browsers=ChromeHeadless --code-coverage",
     "lint": "ng lint"
   },
   "private": true,


### PR DESCRIPTION
A new script "test-ci" was added in the package.json file of the mycargonaut frontend. The purpose is to run tests specifically for the continuous integration environment, where we don't want watch mode, and we need to use headless browser. The script also generates a code coverage report.