### PR TITLE
Update ESLint rules to include max line length

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -10,6 +10,7 @@
     },
     "rules": {
         "indent" : ["error", 4],
-        "require-jsdoc": 0
+        "require-jsdoc": 0,
+        "max-len": ["error", {"code": 165}]
     }
 }


### PR DESCRIPTION
This commit introduces a new ESLint rule that specifies a maximum line length to enhance code readability. The "max-len" rule is set to return an error when the line length exceeds 165 characters.